### PR TITLE
Fix build with -std=c11

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -7,6 +7,7 @@
  * (See accompanying file LICENSE.txt or https://opensource.org/licenses/MIT)
  * SPDX-License-Identifier: MIT
  */
+#define _XOPEN_SOURCE
 #include "tree_sitter/parser.h"
 #include <assert.h>
 #include <ctype.h>


### PR DESCRIPTION
When building with gcc or clang passing `-std=c11` scanner.c fails to build ([helix builds grammars with this argument)](https://github.com/helix-editor/helix/blob/15e07d4db893aec7b9e117c1f88400a68ba98ae2/helix-loader/src/grammar.rs#L512):

gcc:

```
src/scanner.c: In function ‘match_escape’:
src/scanner.c:70:30: warning: implicit declaration of function ‘isascii’ [-Wimplicit-function-declaration]
   70 |                         if (!isascii(lexer->lookahead) ||
      |                              ^~~~~~~
```

clang:

```
src/scanner.c:70:9: error: call to undeclared function 'isascii'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                        if (!isascii(lexer->lookahead) ||
                             ^
src/scanner.c:81:9: error: call to undeclared function 'isascii'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                        if (!isascii(lexer->lookahead) ||
                             ^
src/scanner.c:92:9: error: call to undeclared function 'isascii'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                        if (!isascii(lexer->lookahead) ||
                             ^
src/scanner.c:126:9: error: call to undeclared function 'isascii'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                        if (!isascii(lexer->lookahead) ||
                             ^
4 errors generated.
```

It seems that [`isascii` is deprecated](https://stackoverflow.com/questions/26030928/why-is-isascii-deprecated) and is not visible by default with `-std=c11`. This PR attempts to address that although I'm not 100% sure it's the right fix. A better option might be to define `isascii` in this project if it's not already defined. Open to suggestions