### PR TITLE
chore(gitignore): ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 samples
 log.html
 output
+build/
+node_modules/
+package-lock.json


### PR DESCRIPTION
Add `build/`, `node_modules/`, and `package-lock.json` to `.gitignore` so locally generated build output and npm dependency artifacts are no longer tracked.