### PR TITLE
fix(highlights): match interpolation expression paren colors (#53)

### DIFF
--- a/bindings/python/tests/test_binding.py
+++ b/bindings/python/tests/test_binding.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+import tree_sitter, tree_sitter_d
+
+
+class TestLanguage(TestCase):
+    def test_can_load_grammar(self):
+        try:
+            tree_sitter.Language(tree_sitter_d.language())
+        except Exception:
+            self.fail("Error loading D grammar")

--- a/bindings/swift/TreeSitterDTests/TreeSitterDTests.swift
+++ b/bindings/swift/TreeSitterDTests/TreeSitterDTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+import SwiftTreeSitter
+import TreeSitterD
+
+final class TreeSitterDTests: XCTestCase {
+    func testCanLoadGrammar() throws {
+        let parser = Parser()
+        let language = Language(language: tree_sitter_d())
+        XCTAssertNoThrow(try parser.setLanguage(language),
+                         "Error loading D grammar")
+    }
+}

--- a/queries/helix-highlights.scm
+++ b/queries/helix-highlights.scm
@@ -169,6 +169,14 @@
     "}"
 ] @punctuation.bracket
 
+; The delimiters of an interpolation expression inside an interpolated string.
+; Listed after the bracket rule above so the closing ")" is captured here rather
+; than as a plain bracket; this keeps the opening "$(" and closing ")" the same
+; color instead of the opener inheriting the surrounding string color.
+(interpolation_expression
+    "$(" @punctuation.special
+    ")" @punctuation.special)
+
 [
     ";"
     "."

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -190,10 +190,18 @@
     "("
     ")"
     "["
-    "["
+    "]"
     "{"
     "}"
 ] @punctuation.bracket
+
+; The delimiters of an interpolation expression inside an interpolated string.
+; Listed after the bracket rule above so the closing ")" is captured here rather
+; than as a plain bracket; this keeps the opening "$(" and closing ")" the same
+; color instead of the opener inheriting the surrounding string color.
+(interpolation_expression
+    "$(" @punctuation.special
+    ")" @punctuation.special)
 
 [
     (null)

--- a/test/highlight/interpolation.d
+++ b/test/highlight/interpolation.d
@@ -1,0 +1,8 @@
+string r = i"a $(x)";
+// <- type.builtin
+//     ^ variable
+//       ^ operator
+//          ^ string
+//             ^ punctuation.special
+//               ^ variable
+//                ^ punctuation.special


### PR DESCRIPTION
Fixes #53: in an interpolated string, the closing `)` of an interpolation expression was captured by the generic `@punctuation.bracket` rule while the opening `$(` matched no rule and inherited the surrounding `@string` color, so the two parentheses rendered in different colors. This adds a dedicated rule capturing both `$(` and `)` as `@punctuation.special` (placed after the bracket rule so it overrides the closer) in both `highlights.scm` and `helix-highlights.scm`, with a new highlight test covering it. It also fixes a pre-existing typo in `highlights.scm` where `"["` was listed twice and `"]"` was missing, so closing square brackets were never highlighted. Finally, it adds minimal load-grammar smoke tests for the Python and Swift bindings, mirroring the existing node/go binding tests.