### PR TITLE
test(bitfield): add corpus tests for bitfield declarations (#61)

### DIFF
--- a/test/corpus/bitfield.scm
+++ b/test/corpus/bitfield.scm
@@ -1,0 +1,75 @@
+==================
+Named bitfield
+==================
+
+struct s {
+	int x : 3;
+}
+
+---
+
+(source_file
+  (struct_declaration
+    (struct)
+    (identifier)
+    (aggregate_body
+      (variable_declaration
+        (type
+          (int))
+        (bitfield_declarator
+          (identifier)
+          (int_literal))))))
+
+==================
+Multiple bitfields on one line
+==================
+
+struct s {
+	uint a : 5, flags : 3;
+}
+
+---
+
+(source_file
+  (struct_declaration
+    (struct)
+    (identifier)
+    (aggregate_body
+      (variable_declaration
+        (type
+          (uint))
+        (bitfield_declarator
+          (identifier)
+          (int_literal))
+        (bitfield_declarator
+          (identifier)
+          (int_literal))))))
+
+==================
+Bitfield with initializer and anonymous padding
+==================
+
+struct s {
+	int x : 3 = 2;
+	int : 0;
+}
+
+---
+
+(source_file
+  (struct_declaration
+    (struct)
+    (identifier)
+    (aggregate_body
+      (variable_declaration
+        (type
+          (int))
+        (bitfield_declarator
+          (identifier)
+          (int_literal)
+          (int_literal)))
+      (variable_declaration
+        (type
+          (int))
+        (bitfield_declarator
+          (int_literal))))))


### PR DESCRIPTION
Bitfield grammar support was added back in 96a0ed5 but had no regression tests, leaving issue #61 open. This adds a `test/corpus/bitfield.scm` covering named bitfields, multiple bitfields per line, initializers, and anonymous padding fields. No grammar changes were needed — all D bitfield forms already parse cleanly, and the full test suite passes.

Closes #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)